### PR TITLE
Tiny update to debugging.js

### DIFF
--- a/public/js/debugging.js
+++ b/public/js/debugging.js
@@ -1,4 +1,5 @@
-$("#github").on("submit", function() {
+$("#github").on("submit", function(e) {
+  e.preventDefault();
   var user = $("#user");
 
   emptyCurrentList();


### PR DESCRIPTION
Prevent auto refresh of page view caused by html form submittal

This wasn't a bug at time of video recording because the app appeared to be auto requesting repos based on changes to the input...so not sure if it was an intended additional bug for this exercise or not, but thought I'd point it out just in case!