### PR TITLE
fix: use port 3000 only when environment port is missing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -102,7 +102,7 @@ fastify.get("/exercise/:exerciseId", async (request, reply) => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen(process.env.PORT || 3000);
   } catch (err) {
     fastify.log.error(err);
     process.exit(1);


### PR DESCRIPTION
It is better to tie the port to the one that is provided by the environment when deploying the app. Some services will not expose port 3000. 